### PR TITLE
show figure instead of table in example

### DIFF
--- a/12-mining.qmd
+++ b/12-mining.qmd
@@ -426,7 +426,7 @@ Or any criterion of interest such as positive economic value and
 small fraction of contaminants:
 
 ```{julia}
-estim |> Filter(x -> x.value > 0 && x.S < 0.25)
+estim |> Filter(x -> x.value > 0 && x.S < 0.25) |> Select("value") |> viewer
 ```
 
 ## Summary


### PR DESCRIPTION
In the mining example, it seems more useful to show the image of the filter rather than the table.