### PR TITLE
Fix column alignment in DataFrame output

### DIFF
--- a/01-geodata.qmd
+++ b/01-geodata.qmd
@@ -194,6 +194,7 @@ table representation for data science in Julia is available in
 by @Bogumil2023.
 
 ```{julia}
+#| output: false
 using DataFrames
 
 df = DataFrame(
@@ -204,11 +205,22 @@ df = DataFrame(
 )
 ```
 
+```{julia}
+#| echo: false
+show(stdout, MIME("text/html"), df; header_alignment = :s)
+```
+
 This representation provides additional syntax for accessing
 rows and columns of the table:
 
 ```{julia}
+#| output: false
 df[1,:]
+```
+
+```{julia}
+#| echo: false
+show(stdout, MIME("text/html"), df[1,:]; header_alignment = :s)
 ```
 
 ```{julia}
@@ -216,7 +228,13 @@ df[:,"NAME"]
 ```
 
 ```{julia}
+#| output: false
 df[1:3,["NAME","AGE"]]
+```
+
+```{julia}
+#| echo: false
+show(stdout, MIME("text/html"), df[1:3,["NAME","AGE"]]; header_alignment = :s)
 ```
 
 ```{julia}


### PR DESCRIPTION
This PR fixes the DataFrame column alignment problem as described in #14.

I decided to align the header as DataFrames aligns the column (right for numeric columns and left otherwise). IMHO, it makes the output closer to what people will see when using DataFrames in Jupyter for example.

Closes #14 